### PR TITLE
[Feature] Manual creation for Plot system V5

### DIFF
--- a/src/main/java/com/alpsbte/plotsystemterra/commands/CMD_CreatePlot.java
+++ b/src/main/java/com/alpsbte/plotsystemterra/commands/CMD_CreatePlot.java
@@ -22,6 +22,7 @@ public class CMD_CreatePlot implements CommandExecutor {
         if (!player.hasPermission("plotsystem.createplot")) return true;
 
         try {
+            // Tutorial Plot (DEV ONLY)
             if (ConfigUtil.getInstance().configs[0].getBoolean(ConfigPaths.DEV_MODE)
                     && args.length > 1
                     && args[0].equalsIgnoreCase("tutorial")
@@ -29,6 +30,19 @@ public class CMD_CreatePlot implements CommandExecutor {
                 PlotCreator.createTutorialPlot(player, Integer.parseInt(args[1]));
                 return true;
             }
+
+            // manual input
+            if(args.length == 2) {
+                String cityID = args[0];
+                String difficultyID = args[1];
+
+                if (cityID != null && difficultyID != null) {
+                    PlotCreator.createPlotManually(((Player) sender).getPlayer(), cityID, difficultyID);
+                    return true;
+                }
+            }
+
+            // Creation Menu
             new CreatePlotMenu(player);
         } catch (Exception ex) {
             PlotSystemTerra.getPlugin().getComponentLogger()

--- a/src/main/java/com/alpsbte/plotsystemterra/core/database/CityProjectDataProviderSQL.java
+++ b/src/main/java/com/alpsbte/plotsystemterra/core/database/CityProjectDataProviderSQL.java
@@ -69,6 +69,40 @@ public class CityProjectDataProviderSQL implements CityProjectDataProvider {
         return new CityProject(id, countryCode, isVisible, material, customModelData, serverName);
     }
 
+    public boolean checkCityProjectExist(String id) throws DataException {
+        try (ResultSet rsCity = DatabaseConnection.createStatement(
+                "SELECT EXISTS (" +
+                "    SELECT 1 FROM city_project WHERE city_project_id = ?" +
+                ")")
+                .setValue(id).executeQuery()) {
+
+            boolean exist = false;
+            if (rsCity.next()) exist = rsCity.getBoolean(1);
+
+            DatabaseConnection.closeResultSet(rsCity);
+            return exist;
+        } catch (SQLException ex) {
+            throw new DataException(ex.getMessage());
+        }
+    }
+
+    public boolean checkDifficultyExist(String id) throws DataException {
+        try (ResultSet rs = DatabaseConnection.createStatement(
+                "SELECT EXISTS (" +
+                "    SELECT 1 FROM plot_difficulty WHERE difficulty_id = ?" +
+                ")")
+                .setValue(id).executeQuery()) {
+
+            boolean exist = false;
+            if(rs.next()) exist = rs.getBoolean(1);
+
+            DatabaseConnection.closeResultSet(rs);
+            return exist;
+        } catch (SQLException ex) {
+            throw new DataException(ex.getMessage());
+        }
+    }
+
     @Override
     public CompletableFuture<CityProject> getCityProjectAsync(String id) throws DataException {
         CompletableFuture<CityProject> completableFuture = new CompletableFuture<>();

--- a/src/main/java/com/alpsbte/plotsystemterra/core/database/PlotDataProviderSQL.java
+++ b/src/main/java/com/alpsbte/plotsystemterra/core/database/PlotDataProviderSQL.java
@@ -61,13 +61,14 @@ public class PlotDataProviderSQL implements PlotDataProvider {
             if (connection != null) {
                 connection.setAutoCommit(false);
 
-                try (PreparedStatement stmt = Objects.requireNonNull(connection).prepareStatement("INSERT INTO plot (city_project_id, difficulty_id, outline_bounds, initial_schematic, plot_version, created_by)" +
-                        "VALUES (?, ?, ?, ?, (SELECT si.current_plot_version FROM system_info si WHERE system_id = 1), ?)", Statement.RETURN_GENERATED_KEYS)) {
+                try (PreparedStatement stmt = Objects.requireNonNull(connection).prepareStatement("INSERT INTO plot (city_project_id, difficulty_id, outline_bounds, initial_schematic, plot_version, plot_type, created_by)" +
+                        "VALUES (?, ?, ?, ?, (SELECT si.current_plot_version FROM system_info si WHERE system_id = 1), ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
                     stmt.setString(1, cityProjectId);
                     stmt.setString(2, difficultyId);
                     stmt.setString(3, outlineBounds);
                     stmt.setBytes(4, initialSchematic);
-                    stmt.setString(5, createPlayerUUID.toString());
+                    stmt.setInt(5, 1);
+                    stmt.setString(6, createPlayerUUID.toString());
 
                     stmt.executeUpdate();
 

--- a/src/main/java/com/alpsbte/plotsystemterra/core/plotsystem/PlotCreator.java
+++ b/src/main/java/com/alpsbte/plotsystemterra/core/plotsystem/PlotCreator.java
@@ -177,7 +177,13 @@ public class PlotCreator {
                 return false;
             }
         }
-        else return true;
+        else {
+            // TODO: Validate API
+            player.sendMessage(Utils.ChatUtils.getAlertFormat(text(
+                "Data Provider is set to API! Manually creating plot with this mode is not fully supported!", GOLD))
+            );
+            return true;
+        }
     }
 
     private static void createPlot(Player player, String cityProjectID, String difficultyId) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,7 +7,7 @@ softdepend: [FastAsyncWorldEdit, HeadDatabase]
 commands:
   createplot:
     description: Creates a new plot for the PlotSystem.
-    usage: /createplot
+    usage: /createplot, /createplot <city_project_id> <difficulty_id>
     permission: plotsystem.createplot
   pasteplot:
     description: Pastes a plot manually with specific ID


### PR DESCRIPTION
### Manual Creation Support

* Added `city_project_id` and `difficulty_id` validation in `CityProjectDataProviderSQL`.

* Make `PlotCreator#createPlot` receive String `cityProjectID` parameter as we only use the ID for registering plots anyway.

* Make `PlotCreator#createPlot` **private** which is now callable by `#createPlot(Player, CityProject, String)` or `#createPlotManually(Player, String, String)`

* `PlotCreator#createPlotManually` create a plot with specified city and difficulty ID arguments, fail if IDs does not exist in the database.

### Some general fixes

*  `PlotDataProviderSQL#createPlot(String, String, String, String, UUID, byte)` Missing default `plot_type` column

* Fixed to type `1` as `LOCAL_INSPIRATION_MODE`